### PR TITLE
Update qbittorrent-api to 2021.3.18

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ setup(
     keywords=['prometheus', 'qbittorrent'],
     classifiers=[],
     python_requires='>=3',
-    install_requires=['qbittorrent-api==2020.9.9', 'prometheus_client==0.8.0', 'python-json-logger==0.1.5'],
+    install_requires=['qbittorrent-api==2021.3.18', 'prometheus_client==0.8.0', 'python-json-logger==0.1.5'],
     entry_points={
         'console_scripts': [
             'qbittorrent-exporter=qbittorrent_exporter.exporter:main',


### PR DESCRIPTION
To include https://github.com/rmartin16/qbittorrent-api/commit/72687ca61443d087f01b2b758441e991456b94ab 
in order to fix https://github.com/esanchezm/prometheus-qbittorrent-exporter/issues/3