### PR TITLE
Allow files as config sources

### DIFF
--- a/qbittorrent_exporter/exporter.py
+++ b/qbittorrent_exporter/exporter.py
@@ -165,16 +165,27 @@ class SignalHandler():
         logger.info("Exporter is shutting down")
         self.shutdown = True
 
+def get_config_value(key, default=""):
+    input_path = os.environ.get("FILE__" + key, None)
+    if input_path is not None:
+        try:
+            with open(input_path, "r") as input_file:
+                return input_file.read().strip()
+        except IOError as e:
+            logger.error(f"Unable to read value for {key} from {input_path}: {str(e)}")
+
+    return os.environ.get(key, default)
+
 
 def main():
     config = {
-        "host": os.environ.get("QBITTORRENT_HOST", ""),
-        "port": os.environ.get("QBITTORRENT_PORT", ""),
-        "username": os.environ.get("QBITTORRENT_USER", ""),
-        "password": os.environ.get("QBITTORRENT_PASS", ""),
-        "exporter_port": int(os.environ.get("EXPORTER_PORT", "8000")),
-        "log_level": os.environ.get("EXPORTER_LOG_LEVEL", "INFO"),
-        "metrics_prefix": os.environ.get("METRICS_PREFIX", "qbittorrent"),
+        "host": get_config_value("QBITTORRENT_HOST", ""),
+        "port": get_config_value("QBITTORRENT_PORT", ""),
+        "username": get_config_value("QBITTORRENT_USER", ""),
+        "password": get_config_value("QBITTORRENT_PASS", ""),
+        "exporter_port": int(get_config_value("EXPORTER_PORT", "8000")),
+        "log_level": get_config_value("EXPORTER_LOG_LEVEL", "INFO"),
+        "metrics_prefix": get_config_value("METRICS_PREFIX", "qbittorrent"),
     }
 
     # Register signal handler

--- a/qbittorrent_exporter/exporter.py
+++ b/qbittorrent_exporter/exporter.py
@@ -178,6 +178,17 @@ def get_config_value(key, default=""):
 
 
 def main():
+    # Init logger so it can be used
+    logHandler = logging.StreamHandler()
+    formatter = jsonlogger.JsonFormatter(
+        "%(asctime) %(levelname) %(message)",
+        datefmt="%Y-%m-%d %H:%M:%S"
+    )
+    logHandler.setFormatter(formatter)
+    logger = logging.getLogger()
+    logger.addHandler(logHandler)
+    logger.setLevel("INFO") # default until config is loaded
+
     config = {
         "host": get_config_value("QBITTORRENT_HOST", ""),
         "port": get_config_value("QBITTORRENT_PORT", ""),
@@ -187,20 +198,12 @@ def main():
         "log_level": get_config_value("EXPORTER_LOG_LEVEL", "INFO"),
         "metrics_prefix": get_config_value("METRICS_PREFIX", "qbittorrent"),
     }
+    # set level once config has been loaded
+    logger.setLevel(config["log_level"])
 
     # Register signal handler
     signal_handler = SignalHandler()
 
-    # Init logger
-    logHandler = logging.StreamHandler()
-    formatter = jsonlogger.JsonFormatter(
-        "%(asctime) %(levelname) %(message)",
-        datefmt="%Y-%m-%d %H:%M:%S"
-    )
-    logHandler.setFormatter(formatter)
-    logger = logging.getLogger()
-    logger.addHandler(logHandler)
-    logger.setLevel(config["log_level"])
 
     if not config["host"]:
         logger.error("No host specified, please set QBITTORRENT_HOST environment variable")


### PR DESCRIPTION
Allow "FILE__"+config_name to point to a file containing the config value.
This format matches linuxserver.io containers and is commonly used in other containers as well.

e.g. FILE__QBITTORRENT_HOST contains "/run/secrets/q_host" and the contents of the "/run/secrets/q_host" is "1.2.3.4"