### PR TITLE
Return metrics on connection error

### DIFF
--- a/qbittorrent_exporter/exporter.py
+++ b/qbittorrent_exporter/exporter.py
@@ -199,7 +199,7 @@ def main():
         logger.error("No host specified, please set QBITTORRENT_HOST environment variable")
         sys.exit(1)
     if not config["port"]:
-        logger.error("No post specified, please set QBITTORRENT_PORT environment variable")
+        logger.error("No port specified, please set QBITTORRENT_PORT environment variable")
         sys.exit(1)
 
     # Register our custom collector


### PR DESCRIPTION
Currently, when the exporter fails to connect to qBittorrent, no metrics are returned by `collect`. This means that the `qbittorrent_up` metric will either be `1` or not be scraped, making it impossible to correctly alarm on.

This PR changes this to actual return metrics when the exporter fails to connect to qBittorrent, allowing alarm expressions to be created on `qbittorrent_up`.

It also fixes a typo and a bug in error handling.