### PR TITLE
Reduce Docker image size

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,6 @@
 __pycache__/
 .coverage*
+.git
 .github
 .gitignore
 .pdm*

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,8 +2,10 @@ FROM python:3.11-alpine
 
 # Install package
 WORKDIR /code
-COPY . .
-RUN pip3 install .
+COPY pyproject.toml pdm.lock README.md ./
+COPY qbittorrent_exporter ./qbittorrent_exporter
+RUN pip install . \
+    && rm -rf /root/.cache/pip
 
 ENV QBITTORRENT_HOST=""
 ENV QBITTORRENT_PORT=""


### PR DESCRIPTION
* Copy only required files. Avoid .git, tests, logo...
* Clean up pip cache
* Reduced image size in 4 MB